### PR TITLE
Length of Answer options is limited to a single line #39:

### DIFF
--- a/client/src/app/shared/play-ui/question-pane/question-pane.component.css
+++ b/client/src/app/shared/play-ui/question-pane/question-pane.component.css
@@ -20,6 +20,7 @@ button {
   box-sizing: content-box;
   font-size: xx-large;
   transition: background-color 500ms ease-in;
+  white-space: normal;
 }
 
 .logged-in {

--- a/client/src/app/shared/play-ui/question-pane/question-pane.component.html
+++ b/client/src/app/shared/play-ui/question-pane/question-pane.component.html
@@ -6,7 +6,9 @@
     {{getQuestionText()}}
     <mat-grid-list cols="2" rowHeight="2:1" *ngIf="isShowAnswers()">
       <mat-grid-tile *ngFor="let answer of getAnswers(); let i = index">
-        <button id="button{{i}}" mat-raised-button (click)="onClickAnswer(answer, button._getHostElement())" #button>{{answer.text}}</button>
+        <button id="button{{i}}" mat-raised-button (click)="onClickAnswer(answer, button._getHostElement())" #button>
+            {{answer.text}}
+        </button>
 
       </mat-grid-tile>
     </mat-grid-list>


### PR DESCRIPTION
- Fixed that long text for answers was not broken correctly, it flowed over and was cut off/hidden on a single line